### PR TITLE
set configuration via endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,3 +138,25 @@ This will return the response from the DUT, if any.
 ### Teardown
 
 Posting to the teardown endpoint will tear down cleanly whatever has been setup on the kit - for example it will de activate any created network hotspots.
+
+
+### Configuration
+The autokit will use dummy implementations by default. You can select which implementations to use via the `/config` endpoint:
+
+```sh
+curl -X POST <IP>/config -H 'Content-Type: application/json' -d '{<CONFIG_OPTIONS>}'
+```
+
+For example:
+
+```sh
+curl -X POST localhost/config -H 'Content-Type: application/json' -d '{"serial": "ftdi", "power": "usbrelay"}'
+```
+
+Any config options supported will not be applied. The configuration is stored in a voluem in `/data/config.json`
+
+To fetch the current config:
+
+```sh
+curl localhost/config
+```

--- a/lib/interfaces.d.ts
+++ b/lib/interfaces.d.ts
@@ -35,6 +35,7 @@ interface Serial extends Base{
 
 // specify which peripherals are in use
 interface AutokitConfig{
+    [key: string]: string;//indexer
     power: string;
     sdMux: string;
     network: string; 


### PR DESCRIPTION
Allows for setting autokit configuration through a config file when using the autokit webserver, instead of env vars

For leviathan (OS test framework) env vars are still being used - thats something seperate to the autokit interface however.

There are still env vars used for a few things - will clean those in a separate PR

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>