### PR TITLE
fix wired ethernet reconnects

### DIFF
--- a/lib/features/network/implementations/linux-device/networkManager.ts
+++ b/lib/features/network/implementations/linux-device/networkManager.ts
@@ -63,7 +63,7 @@ class NetworkManager {
 			connection: {
 				id: new dbus.Variant('s', NetworkManager.generateId()),
 				type: new dbus.Variant('s', '802-3-ethernet'),
-				autoconnect: new dbus.Variant('b', false),
+				autoconnect: new dbus.Variant('b', true),
 			},
 			ipv4: { method: new dbus.Variant('s', method) },
 			ipv6: { method: new dbus.Variant('s', 'ignore') },
@@ -91,6 +91,7 @@ class NetworkManager {
 	}
 
 	private async addConnection(connection: any): Promise<string> {
+		console.log(connection)
 		const con = (
 			await this.bus.getProxyObject(
 				'org.freedesktop.NetworkManager',


### PR DESCRIPTION
resolves an issue where wired ethernnet sharing would fail if a connected device powered off then on again. It would not reconnect.


Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>