### PR TITLE
Add /video/liveStream endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,25 @@ The above instructions assume your host device is a balena device connected to b
 To start video capture from the DUT
 
 ```sh
-curl -X POST <IP>/capture/start
+curl -X POST <IP>/video/startCapture
 ```
 
 This will commence capturing until a stop command is sent:
 
 ```sh
-curl -X POST <IP>/capture/stop -o capture.tar.gz
+curl -X POST <IP>/video/stopCapture -o capture.tar.gz
 ```
 
-Which will send a `.tar.gz` archive of all captured frames as jpeg images. 
+Which will send a `.tar.gz` archive of all captured frames as JPEG images and stop capturing. 
+
+You can also watch the stream live using the `/video/liveStream` endpoint as well. 
+**Note: You MUST call `/video/startCapture` first!**
+
+```sh
+vlc http://<IP>/video/liveStream
+```
+
+Which will start showing the MJPEG encoded live stream.
 
 ### Serial
 

--- a/lib/features/video/implementations/linux-video/index.ts
+++ b/lib/features/video/implementations/linux-video/index.ts
@@ -39,7 +39,7 @@ export class LinuxVideo implements Video {
 			this.proc = spawn(
 				'gst-launch-1.0',
 				[
-					`v4l2src ! decodebin ! videocrop left=90 right=90 bottom=70 top=70 ! jpegenc quality=10 ! multifilesink location="${
+					`v4l2src ! decodebin ! jpegenc quality=50 ! multifilesink location="${
 						this.captureFolder
 					}/%06d.jpg"`,
 				],


### PR DESCRIPTION
This PR enables a MJPEG stream on `/video/liveStream`, allowing for easier debugging of the DUT.
This also removes the border crop from the video, as it's unnecessary with USB capture devices.

Change-type: minor
Signed-off-by: Pedro Henrique Kopper <pedro.kopper@balena.io>