### PR TITLE
Bump minimum node version to 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "docs": "rimraf ./docs/ && npx typedoc --tsconfig tsconfig.json"
   },
   "engines": {
-    "node": ">=10.0.0 < 16"
+    "node": ">=16.0.0 < 19"
   },
   "author": "",
   "license": "ISC",
@@ -36,8 +36,7 @@
     "npm": "^8.15.1",
     "serialport": "^10.4.0",
     "tap": "^16.3.0",
-    "tar-fs": "^2.1.1",
-    "tsc": "^2.0.4"
+    "tar-fs": "^2.1.1"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.36",


### PR DESCRIPTION
Node 10 and 12 are already EOL, Node 14 will be EOL in April. Bumping the minimum version to 16 will help us avoid problems in the future.

Signed-off-by: Pedro Henrique Kopper <pedro.kopper@balena.io>