### PR TITLE
bump etcher-sdk to 7.4.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2290,6 +2290,11 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
+    "@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2668,8 +2673,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "optional": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "auto-bind": {
       "version": "4.0.0",
@@ -4166,15 +4170,15 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
     "etcher-sdk": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-7.2.0.tgz",
-      "integrity": "sha512-JoHBeHddlJkwQGMzUP4BpBitio2Erkdu60pu5kBObQ+i58bB/KV54+jcqvrxt36og5HFUlorl5ZKvulvou8sHw==",
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/etcher-sdk/-/etcher-sdk-7.4.8.tgz",
+      "integrity": "sha512-RADYlZCLFH7jmU4Nra9jehLhFm/CRjn2UYxZlzPCbjBrRqG83e+KDXMygN0VoNG8V22StqDpKlrMLRdd34OgYg==",
       "requires": {
-        "@balena/node-beaglebone-usbboot": "^2.0.0",
+        "@balena/node-beaglebone-usbboot": "^2.0.1",
         "@balena/udif": "^1.1.2",
         "@ronomon/direct-io": "^3.0.1",
         "aws4-axios": "^2.4.9",
-        "axios": "^0.26.1",
+        "axios": "^0.27.0",
         "balena-image-fs": "^7.0.6",
         "blockmap": "^4.0.3",
         "check-disk-space": "^2.1.0",
@@ -4182,29 +4186,30 @@
         "debug": "^3.1.0",
         "drivelist": "^9.2.4",
         "file-disk": "^8.0.1",
-        "file-type": "^8.0.0",
+        "file-type": "^16.5.4",
         "gzip-stream": "^1.1.2",
         "lzma-native": "^8.0.6",
         "mountutils": "^1.3.20",
-        "node-raspberrypi-usbboot": "^1.0.2",
-        "outdent": "^0.7.0",
+        "node-raspberrypi-usbboot": "1.0.6",
+        "outdent": "^0.8.0",
         "partitioninfo": "^6.0.2",
         "rwmutex": "^1.0.0",
         "tslib": "^2.0.0",
-        "unbzip2-stream": "^1.4.2",
+        "unbzip2-stream": "github:balena-io-modules/unbzip2-stream#4a54f56a25b58950f9e4277c56db2912d62242e7",
         "unzip-stream": "^0.3.0",
-        "winusb-driver-generator": "^1.2.7",
+        "winusb-driver-generator": "1.2.7",
         "xxhash-addon": "^1.4.0",
         "yauzl": "^2.9.2",
         "zip-part-stream": "^1.0.3"
       },
       "dependencies": {
         "axios": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
           "requires": {
-            "follow-redirects": "^1.14.8"
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
           }
         },
         "debug": {
@@ -4216,9 +4221,24 @@
           }
         },
         "file-type": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/file-type/-/file-type-8.1.0.tgz",
-          "integrity": "sha512-qyQ0pzAy78gVoJsmYeNgl8uH8yKhr1lVhW7JbzJmnlRi0I4R2eEDEJZVKG8agpDnLpacwNbDhLNG/LMdxHD2YQ=="
+          "version": "16.5.4",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+          "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+          "requires": {
+            "readable-web-to-node-stream": "^3.0.0",
+            "strtok3": "^6.2.4",
+            "token-types": "^4.1.1"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
         },
         "lzma-native": {
           "version": "8.0.6",
@@ -4235,6 +4255,30 @@
           "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
           "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
         },
+        "node-raspberrypi-usbboot": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/node-raspberrypi-usbboot/-/node-raspberrypi-usbboot-1.0.6.tgz",
+          "integrity": "sha512-t4c+bmXcvi3VK+YqfWz1k6Fv2XJAkUjwa217ANQCMvfdybpVV6rDD7VD4THXJRrK6zMxZWR0OgMZ/LK3gw/zVQ==",
+          "requires": {
+            "debug": "^4.3.4",
+            "usb": "^2.5.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.3.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+              "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+              "requires": {
+                "ms": "2.1.2"
+              }
+            }
+          }
+        },
+        "outdent": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
+          "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
+        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -4244,6 +4288,10 @@
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
           }
+        },
+        "unbzip2-stream": {
+          "version": "github:balena-io-modules/unbzip2-stream#4a54f56a25b58950f9e4277c56db2912d62242e7",
+          "from": "github:balena-io-modules/unbzip2-stream#4a54f56a25b58950f9e4277c56db2912d62242e7"
         }
       }
     },
@@ -9052,6 +9100,11 @@
         "through": "~2.3"
       }
     },
+    "peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -9379,6 +9432,26 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
+    "readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "requires": {
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
       }
     },
@@ -10069,6 +10142,15 @@
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
+    "strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      }
+    },
     "struct-fu": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/struct-fu/-/struct-fu-1.2.1.tgz",
@@ -10421,6 +10503,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
+    "token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "requires": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      }
     },
     "tough-cookie": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "body-parser": "^1.20.0",
     "dbus-next": "^0.10.2",
     "debug": "^4.3.4",
-    "etcher-sdk": "^7.2.0",
+    "etcher-sdk": "7.4.8",
     "express": "^4.18.1",
     "fs-extra": "^10.1.0",
     "i": "^0.3.7",


### PR DESCRIPTION
This includes an etcher-sdk fix so it works with raspberrypi cm4

Change-type: patch
Signed-off-by: Ryan Cooke <ryan@balena.io>