### PR TITLE
allow for configurable delay on flasher images

### DIFF
--- a/lib/features/digitalRelay/implementations/usb-relay/index.ts
+++ b/lib/features/digitalRelay/implementations/usb-relay/index.ts
@@ -3,6 +3,7 @@ const USBRelay = require("@balena/usbrelay");
 export class DigitalUSBRelay implements DigitalRelay {
     private relayId: string
     private digitalRelay: any
+    private conn: boolean
     constructor(){
         this.relayId = process.env.DIGITAL_RELAY_SERIAL || '959BI'
         let relays = USBRelay.Relays 
@@ -14,6 +15,7 @@ export class DigitalUSBRelay implements DigitalRelay {
                 this.digitalRelay = new USBRelay(relay.devicePath);
             }
         }
+        this.conn = (process.env.USB_RELAY_CONN === 'NC') ? false: true // if the user specifies they have set up the connection to be NC
     }
 
     async setup(): Promise<void> {
@@ -23,13 +25,13 @@ export class DigitalUSBRelay implements DigitalRelay {
     // Power on the DUT
     async on(): Promise<void> {
         console.log(`Toggling digital relay on`)
-        await this.digitalRelay.setState(1, true);
+        await this.digitalRelay.setState(0, this.conn);
     }
 
     // Power off the DUT
     async off(): Promise<void> {
         console.log(`Toggling digital relay off`)
-        await this.digitalRelay.setState(0, false);
+        await this.digitalRelay.setState(0, !this.conn);
     }
 
     async getState(): Promise<string> {

--- a/lib/flashing/index.ts
+++ b/lib/flashing/index.ts
@@ -136,6 +136,10 @@ async function checkDutPower(autoKit:Autokit) {
 }
 
 async function flashFlasher(filename: string, autoKit: Autokit, jumper: boolean){
+    // this delay is how long to wait after internal flashing before trying to re power the board. For the case where devices have capacitors that
+    // take time to drain
+    const powerOnDelay = Number(process.env.CAP_DELAY) || 1000*60;
+
     // first flash sd
     console.log(`Entering flash method for flasher images...`);
     await flashSD(filename, autoKit);
@@ -207,10 +211,14 @@ async function flashFlasher(filename: string, autoKit: Autokit, jumper: boolean)
     }
 
     // add a slight delay here to avoid powering off and on too quickly
-    await delay(1000*60)
+    await delay(powerOnDelay)
 }
 
 async function flashUsbBoot(filename: string, autoKit: Autokit, port: string, power: boolean, jumper: boolean){
+     // this delay is how long to wait after internal flashing before trying to re power the board. For the case where devices have capacitors that
+    // take time to drain
+    const powerOnDelay = Number(process.env.CAP_DELAY) || 1000*60;
+    
     console.log(`Entering flash method for USB-Boot devices...`);
 
     await autoKit.power.off();
@@ -326,7 +334,7 @@ async function flashUsbBoot(filename: string, autoKit: Autokit, port: string, po
         await toggleUsb(false, port);
         await toggleUsb(false, port);
     }
-    await delay(10*1000);
+    await delay(powerOnDelay);
 }
    
 /**


### PR DESCRIPTION
Some devices have capacitors that mean you must wait for them to discharge before re applying power to the DUT after it has flashed. This adds an env var `CAP_DELAY` to add a configurable wait.