### PR TITLE
add crelay implementation

### DIFF
--- a/lib/features/power/implementations/crelay/README.md
+++ b/lib/features/power/implementations/crelay/README.md
@@ -1,0 +1,15 @@
+# crelay
+
+## Hardware
+This implementation is to be used when a relay is being used that is controlled via the `crelay` tool: https://github.com/balena-io-hardware/crelay
+
+## Dependencies
+If using this implementation, the host must have the following setup:
+
+```
+apt-get install libftdi1 libftdi-dev libhidapi-libusb0 libhidapi-dev libusb-1.0-0 libusb-1.0-0-dev 
+git clone https://github.com/balena-io-hardware/crelay.git
+cd crelay/src 
+make [DRV_CONRAD=n] [DRV_SAINSMART=n] [DRV_HIDAPI=n] 
+make install
+```

--- a/lib/features/power/implementations/crelay/index.ts
+++ b/lib/features/power/implementations/crelay/index.ts
@@ -1,0 +1,46 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+export class Crelay implements Power {
+    private relayId: number
+    private connOn: string
+    private connOff: string
+
+    constructor(){
+        this.relayId = Number(process.env.CRELAY_POWER_CHANNEL) || 1; // indexing of relay channels starts at 1 for this device.
+        this.connOn = (process.env.USB_RELAY_CONN === 'NC') ? 'OFF': 'ON' // if the user specifies they have set up the connection to be NC
+        this.connOff = (process.env.USB_RELAY_CONN === 'NC') ? 'ON': 'OFF' // if the user specifies they have set up the connection to be NC
+    }
+
+    async setup(): Promise<void> {
+        // this retrieves info about the relay being used, and its serial
+        let info = await execAsync(`crelay -i ${this.relayId}`);
+        console.log(`Crelay controlled relay being used for power, channel: ${this.relayId}.`);
+        console.log(info.stdout);
+    }
+
+    // Power on the DUT
+    async on(voltage?: number): Promise<void> {
+        console.log(`Powering on DUT...`);
+        await execAsync(`crelay ${this.relayId} ${this.connOn}`);
+    }
+
+    // Power off the DUT
+    async off(): Promise<void> {
+        console.log(`Powering off DUT...`);
+        await execAsync(`crelay ${this.relayId} ${this.connOff}`);
+    }
+
+    async getState(): Promise<string> {
+        // TODO return state of power on/off
+        let state = await execAsync(`crelay ${this.relayId}`);
+        return state.stdout;
+    }
+
+    async teardown(): Promise<void> {
+        await this.off();
+    }
+
+}

--- a/lib/features/power/index.ts
+++ b/lib/features/power/index.ts
@@ -1,9 +1,11 @@
 import { AutokitRelay } from "./implementations/autokit-relay";
 import { DummyPower } from "./implementations/dummy-power";
+import { Crelay } from "./implementations/crelay";
 
 const powerImplementations: {[key: string]: Type<Power> } = {
 	autokitRelay: AutokitRelay,
 	dummyPower: DummyPower,
+	crelay: Crelay,
 };
 
 export { powerImplementations }


### PR DESCRIPTION
Add support for crelay supported usb relays: https://github.com/ondrej1024/crelay

This tool can be used to control the original usb relay too - technically making the AutokitRelay class redundant - but leaving it there for now for removal at a later day following in the field testing of this new implementation. 

To be used with leviathan-worker, an additional PR (pending) on that repo must be merged. 

To select this device, the env var `POWER=crelay` can be set

Change-type: patch`