### PR TITLE
search for correct sg device with linuxAut mux

### DIFF
--- a/lib/features/sd-mux/implementations/linux-gmbh/index.ts
+++ b/lib/features/sd-mux/implementations/linux-gmbh/index.ts
@@ -5,12 +5,24 @@ import { delay } from 'bluebird';
 const execAsync = promisify(exec);
 
 export class LinuxAut implements SdMux {
-    public DEV_SD = '/dev/disk/by-id/usb-LinuxAut_sdmux_HS-SD_MMC_000000000628-0:0'
+    public DEV_SD = '/dev/disk/by-id/usb-LinuxAut_sdmux_HS-SD_MMC_000000000628-0:0';
+    private sgDev = 'sg*';
     constructor(){
     }
 
     async setup(): Promise<void> {
-        await execAsync('usbsdmux /dev/sg* host');
+        // determine the /dev/sg* device number for the mux
+        let devList = await execAsync(`ls /sys/class/scsi_generic/`);
+        for (let device of devList.stdout.split("\n")){
+            let vendor = await execAsync(`cat /sys/class/scsi_generic/${device}/device/vendor`);
+            if(vendor.stdout.trim() === 'LinuxAut'){
+                this.sgDev = device.trim();
+                console.log(`SD mux is at /dev/${this.sgDev}!`);
+                break;
+            }
+        }
+
+        await execAsync(`usbsdmux /dev/${this.sgDev} host`);
         let sdCheck = await execAsync(`ls /dev/disk/by-id/usb-LinuxAut_sdmux_HS-SD_MMC_* | head -1`);
         this.DEV_SD = sdCheck.stdout.trim();
         console.log(`SD MUX is: ${this.DEV_SD}`);
@@ -19,12 +31,12 @@ export class LinuxAut implements SdMux {
     async toggleMux(state: string): Promise<void> {
         if(state === 'host'){
             console.log('Switching SD card to host');
-            await execAsync('usbsdmux /dev/sg* host');
+            await execAsync(`usbsdmux /dev/${this.sgDev} host`);
             // it can take some time before the mux is toggled - so just to be sure, we can add some delay here
             await delay(5000);
         } else if(state === 'dut'){
             console.log('Switching SD card to DUT');
-            await execAsync('usbsdmux /dev/sg* dut');
+            await execAsync(`usbsdmux /dev/${this.sgDev} dut`);
             // it can take some time before the mux is toggled - so just to be sure, we can add some delay here
             await delay(5000);
         }


### PR DESCRIPTION
We encountered an issue when using a host for the autokit that had multiple scsi-generic (`/dev/sg*`) devices attached. We were using `/dev/sg*` to address the mux which caused problems when multiple devices were attached. 

Added a small piece of setup that searches for the correct sg device, using the vendor name.

Change-type: patch