### PR TITLE
lib/flashing/devices: Add json for jetson-xavier

### DIFF
--- a/lib/flashing/devices/jetson-xavier.json
+++ b/lib/flashing/devices/jetson-xavier.json
@@ -1,0 +1,3 @@
+{
+    "type": "jetson"
+}


### PR DESCRIPTION
The Xavier AGX is flashed using the jetson-flash node app, and boots from the eMMC.

Change-type: patch