### PR TITLE
power: crelay: clean up and enable use of multiple compatible devices

### DIFF
--- a/lib/features/power/implementations/autokit-relay/README.md
+++ b/lib/features/power/implementations/autokit-relay/README.md
@@ -14,5 +14,5 @@ They used a HID interface and are controllable via:
 ## Configuration
 
 - `POWER_RELAY_SERIAL`: the serial of the relay. An example of how to obtain that is here: https://github.com/darrylb123/usbrelay?tab=readme-ov-file#usage 
-- `POWER_RELAY_NUM`: for specifying which channel of the relay is being used for the jumper/boot switch control in the case of multiple channels being on the relay. Default is `0` which leads to all channels being toggled - actual channel numbers start at `1`
+- `POWER_RELAY_NUM`: for specifying which channel of the relay is being used for the power control of the DUT in the case of multiple channels being on the relay. Default is `0` which leads to all channels being toggled - actual channel numbers start at `1`
 - `USB_RELAY_CONN`: `NO` or `NC` - for selecting if the normally open or closed configuration is used - default is `NO` and recommended

--- a/lib/features/power/implementations/crelay/README.md
+++ b/lib/features/power/implementations/crelay/README.md
@@ -10,5 +10,6 @@ This implementation is to be used when a relay is being used that is controlled 
 
 ## Configuration
 
-- `CRELAY_POWER_CHANNEL`: the relay channel connected to the DUT power
-- `USB_RELAY_CONN`: `NC` or `NO` - for normally open or normally closed relay configuration
+- `POWER_RELAY_SERIAL`: the serial of the relay. If not specified, the first detected device will be selected. This can cause issues if USB to serial FTDI adapters are also connected to the host, as they are controllable via `crelay` tools. 
+- `POWER_RELAY_NUM`: for specifying which channel of the relay is being used for controlling the power to the DUT, in the case where multiple channels on the same relay are being used. Defaults to 1 if not specified
+- `USB_RELAY_CONN`: `NC` or `NO` - for normally open or normally closed relay configuration. Default is `NO` and recommended

--- a/lib/features/power/implementations/crelay/index.ts
+++ b/lib/features/power/implementations/crelay/index.ts
@@ -4,14 +4,22 @@ import { promisify } from 'util';
 const execAsync = promisify(exec);
 
 export class Crelay implements Power {
-    private relayId: number
+    private relayChannel: number
     private connOn: string
     private connOff: string
+    private relaySerial: string
+    private crelayCmd: string
 
     constructor(){
-        this.relayId = Number(process.env.CRELAY_POWER_CHANNEL) || 1; // indexing of relay channels starts at 1 for this device.
+        // this implmentation uses the crelay too in interactive mode # https://github.com/ondrej1024/crelay?tab=readme-ov-file#command-line-interface
+        // commands take the following forms:
+        // crelay [-s <serial number>] -i | [<relay number>] [ON|OFF]
+
+        this.relayChannel = Number(process.env.POWER_RELAY_NUM) || 1; // indexing of relay channels starts at 1 for this device.
         this.connOn = (process.env.USB_RELAY_CONN === 'NC') ? 'OFF': 'ON' // if the user specifies they have set up the connection to be NC
         this.connOff = (process.env.USB_RELAY_CONN === 'NC') ? 'ON': 'OFF' // if the user specifies they have set up the connection to be NC
+        this.relaySerial = (process.env.POWER_RELAY_SERIAL) ? `-s ${process.env.POWER_RELAY_SERIAL} `: ''; // if not specified, then the check will evaluate to false - and give an empty string
+        this.crelayCmd = `crelay ${this.relaySerial}${this.relayChannel}`;
     }
 
     async setup(): Promise<void> {
@@ -23,8 +31,9 @@ export class Crelay implements Power {
             await execAsync('cp /usr/app/crelay/src/crelay /usr/local/bin/crelay');
 
             // this retrieves info about the relay being used, and its serial
-            let info = await execAsync(`crelay -i ${this.relayId}`);
-            console.log(`Crelay controlled relay being used for power, channel: ${this.relayId}.`);
+            console.log(`Using crelay command prefix: ${this.crelayCmd}`)
+
+            let info = await execAsync(`crelay -i`);
             console.log(info.stdout);
         } catch(e){
             console.log(e)
@@ -35,18 +44,17 @@ export class Crelay implements Power {
     // Power on the DUT
     async on(voltage?: number): Promise<void> {
         console.log(`Powering on DUT...`);
-        await execAsync(`crelay ${this.relayId} ${this.connOn}`);
+        await execAsync(`${this.crelayCmd} ${this.connOn}`);
     }
 
     // Power off the DUT
     async off(): Promise<void> {
         console.log(`Powering off DUT...`);
-        await execAsync(`crelay ${this.relayId} ${this.connOff}`);
+        await execAsync(`${this.crelayCmd} ${this.connOff}`);
     }
 
     async getState(): Promise<string> {
-        // TODO return state of power on/off
-        let state = await execAsync(`crelay ${this.relayId}`);
+        let state = await execAsync(`${this.crelayCmd}`);
         return state.stdout;
     }
 


### PR DESCRIPTION
This allows for specifying the serial number of the crelay compatible relay being used to control power - for the case where multiple connected devices are picked up by crelay tooling (e.g an FTDI usb to serial adapter)

supersedes https://github.com/balena-io-hardware/autokit-interface-sw/pull/81 


Change-type: minor