### PR TITLE
flashing/devices: Add Jetson AGX Orin Devkit 64GB

### DIFF
--- a/lib/flashing/devices/jetson-agx-orin-devkit-64gb.json
+++ b/lib/flashing/devices/jetson-agx-orin-devkit-64gb.json
@@ -1,0 +1,4 @@
+{
+    "type": "jetson",
+    "nvme": true
+}


### PR DESCRIPTION
Even if the flasher image will be switched
to provisioning the eMMC, a flasher image
will still be used so nvme can be kept in the
json.

Change-type: patch