### PR TITLE
Update iot-gate-imx8plus flashing args, add iotdir-imx8p json files

### DIFF
--- a/lib/flashing/devices/iot-gate-imx8plus-d1d8.json
+++ b/lib/flashing/devices/iot-gate-imx8plus-d1d8.json
@@ -1,4 +1,3 @@
 {
-    "type": "iot-gate",
-    "dram": "d1d8"
+    "type": "iot-gate"
 }

--- a/lib/flashing/devices/iot-gate-imx8plus.json
+++ b/lib/flashing/devices/iot-gate-imx8plus.json
@@ -1,4 +1,3 @@
 {
-    "type": "iot-gate",
-    "dram": "d2d4"
+    "type": "iot-gate"
 }

--- a/lib/flashing/devices/iotdin-imx8p-d1d8.json
+++ b/lib/flashing/devices/iotdin-imx8p-d1d8.json
@@ -1,0 +1,3 @@
+{
+    "type": "iot-gate"
+}

--- a/lib/flashing/devices/iotdin-imx8p.json
+++ b/lib/flashing/devices/iotdin-imx8p.json
@@ -1,0 +1,3 @@
+{
+    "type": "iot-gate"
+}

--- a/lib/flashing/index.ts
+++ b/lib/flashing/index.ts
@@ -573,7 +573,7 @@ async function flashJetson(filename: string, autoKit: Autokit, deviceType: strin
    
 }
 
-async function flashIotGate(filename: string, autoKit: Autokit, port: usbPort, dram: string){
+async function flashIotGate(filename: string, autoKit: Autokit, port: usbPort){
     const powerOnDelay = Number(process.env.CAP_DELAY) || 1000*60*5;
 
     // ensure we have latest flasher tool
@@ -604,8 +604,6 @@ async function flashIotGate(filename: string, autoKit: Autokit, port: usbPort, d
                 [
                 '-a',
                 'armv7',
-                '-d',
-                dram,
                 '-i',
                 filename
                 ], 
@@ -675,7 +673,7 @@ async function flash(filename: string, deviceType: string, autoKit: Autokit, por
             if(port === undefined){
                 throw new Error('No usb port specified!')
             }
-            await flashIotGate(filename, autoKit, port, flashProcedure.dram)
+            await flashIotGate(filename, autoKit, port)
         }
     }
 }


### PR DESCRIPTION
In https://github.com/balena-os/iot-gate-imx8plus-flashtools/pull/10 we removed the DRAM arg from the flashing tools, and thus need to update the autokit flashing procedure.

https://github.com/balena-io/contracts/pull/434 proposes two new IOTDIN-IMX8P device-types which share the same flashing tools and provisioning procedure with the IOT-GATE-IMX8PLUS devices, so we add their json files in this PR.
