### PR TITLE
sd-mux: linux-gmbh: fix seach for device for new mux board revision

### DIFF
--- a/lib/features/sd-mux/implementations/linux-gmbh/index.ts
+++ b/lib/features/sd-mux/implementations/linux-gmbh/index.ts
@@ -23,7 +23,7 @@ export class LinuxAut implements SdMux {
         }
 
         await execAsync(`usbsdmux /dev/${this.sgDev} host`);
-        let sdCheck = await execAsync(`ls /dev/disk/by-id/usb-LinuxAut_sdmux_HS-SD_MMC_* | head -1`);
+        let sdCheck = await execAsync(`ls /dev/disk/by-id/usb-LinuxAut* | head -1`);
         this.DEV_SD = sdCheck.stdout.trim();
         console.log(`SD MUX is: ${this.DEV_SD}`);
     }


### PR DESCRIPTION
new revisions of this sd mux have a different identifier - so we have to update the string used to search for it so it works with both old and new

Change-type: patch